### PR TITLE
SqlConnector syncronization with connection string

### DIFF
--- a/Excavator/ConnectPage.xaml
+++ b/Excavator/ConnectPage.xaml
@@ -101,17 +101,16 @@
             Content="Connect" IsEnabled="True"
             Click="btnConnect_Click" />
 
-        <Label Name="lblDbConnect" Visibility="Hidden"
+        <Label Name="lblDbConnect" Visibility="Hidden" Content="{Binding DbConnectMsg}"
             Grid.Row="4" HorizontalAlignment="Center"
             Grid.ColumnSpan="2" VerticalAlignment="Bottom"
-            Style="{StaticResource labelStyleAlert}">
-            Could not connect to database. Please verify the server is online.
-        </Label>
+            Style="{StaticResource labelStyleAlert}" />
+        
 
         <!-- Navigation -->
         <Grid Grid.Row="5" Grid.ColumnSpan="2">
             <Button Style="{StaticResource buttonStylePrimary}"
-                x:Name="btnNext" Margin="10,0"
+                x:Name="btnNext" Margin="10,0" IsEnabled="{Binding OkToProceed}"
                 VerticalAlignment="Center"
                 Grid.Column="1" HorizontalAlignment="Right"
                 Click="btnNext_Click">

--- a/Excavator/Excavator.csproj
+++ b/Excavator/Excavator.csproj
@@ -287,6 +287,7 @@
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <UsingTask TaskName="CosturaCleanup" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" TaskFactory="CodeTaskFactory">
     <ParameterGroup>

--- a/Excavator/SQLConnector.xaml
+++ b/Excavator/SQLConnector.xaml
@@ -38,7 +38,7 @@
                     <ColumnDefinition Width="1*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <ComboBox x:Name="SqlServerName"
+                <ComboBox 
                 Margin="3"
                 IsEditable="True"
                 ItemsSource="{Binding ElementName=_this, Path=Servers}"
@@ -67,12 +67,12 @@
                     Grid.Row="2"
                     Grid.ColumnSpan="2">
                 <StackPanel>
-                    <RadioButton Content="Windows Authentication"
-                    Margin="3"
+                    <RadioButton Content="Windows Authentication" Checked="ValidateConnection"  
+                                 Margin="3"
                     x:Name="SqlAuthTypeWindows"
                     IsChecked="{Binding ElementName=_this, Path=ConnectionString.IntegratedSecurity, UpdateSourceTrigger=PropertyChanged}">
                     </RadioButton>
-                    <RadioButton Content="Sql Authentication"
+                    <RadioButton Content="Sql Authentication" Checked="ValidateConnection"  
                     Margin="3"
                     x:Name="SqlAuthTypeSql">
                         <RadioButton.Style>
@@ -117,6 +117,10 @@
                     </Grid>
                 </StackPanel>
             </GroupBox>
+            <Border Background="#88ffffff" Grid.RowSpan="5" Grid.ColumnSpan="3" Visibility="{Binding ElementName=_this, Path=DatabasesLoading, Converter={StaticResource BooleanToVisibilityConverter}}" 
+                    >
+                <TextBlock Text="          " HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
         </Grid>
     </GroupBox>
 </UserControl>


### PR DESCRIPTION
These changes are to fix two issues.
1. SQL connector should wait for database lookup before saving a connection string
2. SQL Connector doesn't refresh connection on credential change
