### PR TITLE
Keep visitors segregated

### DIFF
--- a/Excavator.FellowshipOne/Maps/People.cs
+++ b/Excavator.FellowshipOne/Maps/People.cs
@@ -370,7 +370,7 @@ namespace Excavator.F1
                                 familyRoleId = FamilyRole.Visitor;
                             }
 
-                            if ( familyRole == "child" || person.Age < 18 )
+                            else if ( familyRole == "child" || person.Age < 18 )
                             {
                                 familyRoleId = FamilyRole.Child;
                             }


### PR DESCRIPTION
This was a program flow error.  Previously visitors, who are mostly < 18 years old, were marked visitors but then immediately changed to children resulting in them appearing as a child of the host family.  Adding the "else" ensures that, later on, these people are moved into their own families and a known relationship (allowing check-in) is created between the host and the visitor.